### PR TITLE
add flag to determine terminating error vs. non-terminating error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
 module.exports = SemanticReleaseError
 
 SemanticReleaseError.prototype = new Error()
-function SemanticReleaseError (message, code) {
+
+function SemanticReleaseError (message, code, stop) {
+  if (stop === undefined) stop = true
+
   Error.captureStackTrace(this, this.constructor)
   this.name = this.constructor.name
   this.message = message
   this.code = code
+  this.stop = stop
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,5 +9,5 @@ function SemanticReleaseError (message, code, stop) {
   this.name = this.constructor.name
   this.message = message
   this.code = code
-  this.stop = stop
+  this.stop = Boolean(stop)
 }

--- a/test/index.js
+++ b/test/index.js
@@ -27,11 +27,18 @@ test('sets message and code', function (t) {
   t.end()
 })
 
-test('terminating or non-terminating', function (t) {
+test('signal terminating or non-terminating', function (t) {
   var terminatingError = new SemanticReleaseError()
   var nonTerminatingError = new SemanticReleaseError('ENOFOO', 'bar', false)
 
   t.is(terminatingError.stop, true)
   t.is(nonTerminatingError.stop, false)
+  t.end()
+})
+
+test('typecast stop signal', function (t) {
+  var error = new SemanticReleaseError('ENOFOO', 'bar', 'false')
+
+  t.is(error.stop, true)
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -26,3 +26,12 @@ test('sets message and code', function (t) {
   t.is(error.message, message)
   t.end()
 })
+
+test('terminating or non-terminating', function (t) {
+  var terminatingError = new SemanticReleaseError()
+  var nonTerminatingError = new SemanticReleaseError('ENOFOO', 'bar', false)
+
+  t.is(terminatingError.stop, true)
+  t.is(nonTerminatingError.stop, false)
+  t.end()
+})


### PR DESCRIPTION
> Related: https://github.com/semantic-release/semantic-release/issues/340

allows errors to be flagged as non-terminating (defaults to a terminating error for backwards