### PR TITLE
fix: Include stacktrace and name in SemanticReleaseError

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
-module.exports = SemanticReleaseError;
-
-SemanticReleaseError.prototype = new Error();
-
-function SemanticReleaseError(message, code) {
-  Error.captureStackTrace(this, this.constructor);
-  this.name = this.constructor.name;
-  this.message = message;
-  this.code = code;
-}
+module.exports = class SemanticReleaseError extends Error {
+  constructor(message, code) {
+    super(message);
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.code = code;
+  }
+};

--- a/test/helpers/throw-error.js
+++ b/test/helpers/throw-error.js
@@ -1,0 +1,5 @@
+import SemanticReleaseError from '../../index';
+
+export default () => {
+  throw new SemanticReleaseError('message', 'code');
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import SemanticReleaseError from '../index';
+import throwError from './helpers/throw-error';
 
 test('Instanciates error', t => {
   const error = new SemanticReleaseError();
@@ -14,11 +15,17 @@ test('Sets message', t => {
   t.is(error.message, message);
 });
 
-test('Sets message and code', function(t) {
+test('Sets message and code', t => {
   const code = 'ENOFOO';
   const message = 'bar';
   const error = new SemanticReleaseError(message, code);
 
   t.is(error.code, code);
   t.is(error.message, message);
+});
+
+test('Include the stacktrace and name', async t => {
+  const error = await t.throws(() => throwError());
+  t.regex(error.stack, /helpers\/throw-error/);
+  t.is(error.name, 'SemanticReleaseError');
 });


### PR DESCRIPTION
SemanticReleaseError was not inheriting Error so the stacktrace and the name were not included.

See https://github.com/semantic-release/semantic-release/pull/480#pullrequestreview-72660167