### PR TITLE
TypeScript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+export declare class SemanticReleaseError extends Error {
+  code: string | undefined;
+  details: string | undefined;
+  semanticRelease: true;
+  constructor(message: string, code?: string, details?: string);
+}
+
+export default SemanticReleaseError;
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,5 +5,7 @@ export declare class SemanticReleaseError extends Error {
   constructor(message: string, code?: string, details?: string);
 }
 
+export declare function isSemanticReleaseError(object: Error): object is SemanticReleaseError;
+
 export default SemanticReleaseError;
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
-module.exports = class SemanticReleaseError extends Error {
+'use strict';
+
+class SemanticReleaseError extends Error {
   constructor(message, code, details) {
     super(message);
     Error.captureStackTrace(this, this.constructor);
@@ -7,4 +9,8 @@ module.exports = class SemanticReleaseError extends Error {
     this.details = details;
     this.semanticRelease = true;
   }
-};
+}
+
+exports.default = SemanticReleaseError;
+exports.SemanticReleaseError = SemanticReleaseError;
+Object.defineProperty(exports, '__esModule', {value: true});

--- a/index.js
+++ b/index.js
@@ -11,6 +11,15 @@ class SemanticReleaseError extends Error {
   }
 }
 
+function isSemanticReleaseError(object) {
+  return (
+    object !== null &&
+    typeof object === 'object' &&
+    (object instanceof SemanticReleaseError || (object instanceof Error && object.semanticRelease === true))
+  );
+}
+
 exports.default = SemanticReleaseError;
 exports.SemanticReleaseError = SemanticReleaseError;
+exports.isSemanticReleaseError = isSemanticReleaseError;
 Object.defineProperty(exports, '__esModule', {value: true});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "typings": "index.d.ts",
   "nyc": {
     "include": [
       "index.js"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import SemanticReleaseError from '..';
+import {SemanticReleaseError, isSemanticReleaseError} from '..';
 import throwError from './helpers/throw-error';
 import InheritedError from './helpers/inherited-error';
 import throwInheritedError from './helpers/throw-inherited-error';
@@ -10,6 +10,17 @@ test('Instanciates error', t => {
   t.true(error instanceof Error);
   t.true(error.semanticRelease);
   t.true(error instanceof SemanticReleaseError);
+});
+
+test('Narrows error', t => {
+  t.true(isSemanticReleaseError(new SemanticReleaseError()));
+  t.false(isSemanticReleaseError(new TypeError()));
+  t.false(isSemanticReleaseError(1));
+  t.false(isSemanticReleaseError('string'));
+  t.false(isSemanticReleaseError(null));
+  t.false(isSemanticReleaseError([]));
+  t.false(isSemanticReleaseError({}));
+  t.false(isSemanticReleaseError(false));
 });
 
 test('Sets message', t => {


### PR DESCRIPTION
This branch adds the `index.d.ts` file that adds TypeScript typings for the `SemanticReleaseError`.

It also does a few other things, RFC:

### `isSemanticReleaseError`

This function allows someone to determine if an error is a `SemanticReleaseError` without having to know the internals or structure of the exception. It also means that if the shape of the error changes in the future, we can update the function to still identify the exception (in case of a breaking change release). It also allows the TypeScript compiler to narrow the type. The following works well in TypeScript:

```ts
import { isSemanticReleaseError } from '@semantic-release/error';
try {
  // ...
} catch (error) {
  if (!isSemanticReleaseError(error)) {
    throw error;
  }
  // `tsc` *knows* that error is an instance of `SemanticReleaseError` now
  // it knows the available properties and their type
  console.error(`${error.code} ${error.message}`);
  if (error.details !== undefined) {
    console.error(error.details);
  }
}
```

### ECMAscript Module Exports

The `index.js` has been changed to add the `__esModule` hidden property on the exports. This allows the module to be interpreted as an ECMAscript module. This allows both default and loose exports.