### PR TITLE
chore(ci): update Node.js engine version and test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18.0.0
-          - 19
-          - 20
+          - 22.22.2
+          - 24.15
+          - 24
 
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prettier": "3.9.6"
   },
   "engines": {
-    "node": ">=18"
+    "node": "^22.22.2 || >=24.15"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
This pull request updates the Node.js version requirements across the project to ensure compatibility with newer Node.js releases. The main changes are:

**Node.js version updates:**

* Updated the Node.js versions in the GitHub Actions workflow (`.github/workflows/test.yml`) to test against versions `22.22.2`, `24.15`, and `24` instead of older versions (`18.17`, `20.6.1`, `20`).
* Updated the `engines.node` field in `package.json` to require Node.js `^22.22.2` or `>=24.15`, dropping support for older Node.js versions.

BREAKING CHANGES: Now require Node.js `^22.22.2` or `>=24.15`